### PR TITLE
skip check for outdatedness

### DIFF
--- a/src/builder/__init__.py
+++ b/src/builder/__init__.py
@@ -58,20 +58,13 @@ def are_libs_outdated():
     return len(modified_files) > 0
 
 
-def update_compiled_libs():
+def compile_schemata():
     info("Remove old files")
     shutil.rmtree(TFLITE_ROOT)
     info("Compile schemata")
     for schema_file in (f for f in SCHEMA_ROOT.iterdir() if f.suffix == ".fbs"):
         compile_schema(schema_file, PACKAGES_ROOT)
     info("Done")
-
-
-def compile_schemata():
-    if are_libs_outdated():
-        update_compiled_libs()
-    else:
-        info("No upstream changes")
 
 
 @click.group()


### PR DESCRIPTION
- this check is currently done in CI
- repeated execution yields the same state

without this change, due to changes in the CI pipeline, the files are never recompiled (see [this run](https://github.com/doo/tflite-metadata/actions/runs/4496936400/jobs/7912062134) under "Compile python files from Schemata")